### PR TITLE
feat: ignore flexbox and multicolumn declarations (#1)

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -8,6 +8,12 @@ module.exports = {
 			options: {
 				preserve: false
 			}
+		},
+		'ignore-flexbox': {
+			message: 'ignore flexbox declarations'
+		},
+		'ignore-multicolumn': {
+			message: 'ignore multi column declarations'
 		}
 	}
 };

--- a/index.js
+++ b/index.js
@@ -3,20 +3,25 @@ import postcss from 'postcss';
 // gap shorthand property matcher
 const gapPropertyRegExp = /^(column-gap|gap|row-gap)$/i;
 
+// filter `display: grid` declarations
+const isDisplayGrid = (node) => node.prop === 'display' && node.value === 'grid';
+
 export default postcss.plugin('postcss-gap-properties', opts => {
 	const preserve = 'preserve' in Object(opts) ? Boolean(opts.preserve) : true;
 
 	return root => {
 		// for each shorthand gap, column-gap, or row-gap declaration
 		root.walkDecls(gapPropertyRegExp, decl => {
-			// insert a grid-* fallback declaration
-			decl.cloneBefore({
-				prop: `grid-${decl.prop}`
-			});
+			if (decl.parent.some(isDisplayGrid)) {
+				// insert a grid-* fallback declaration
+				decl.cloneBefore({
+					prop: `grid-${decl.prop}`
+				});
 
-			// conditionally remove the original declaration
-			if (!preserve) {
-				decl.remove();
+				// conditionally remove the original declaration
+				if (!preserve) {
+					decl.remove();
+				}
 			}
 		})
 	};

--- a/test/basic.css
+++ b/test/basic.css
@@ -1,4 +1,5 @@
 test {
+	display: grid;
 	order: 1;
 	gap: 20px;
 	order: 2;

--- a/test/basic.expect.css
+++ b/test/basic.expect.css
@@ -1,4 +1,5 @@
 test {
+	display: grid;
 	order: 1;
 	grid-gap: 20px;
 	gap: 20px;

--- a/test/basic.preserve-false.expect.css
+++ b/test/basic.preserve-false.expect.css
@@ -1,4 +1,5 @@
 test {
+	display: grid;
 	order: 1;
 	grid-gap: 20px;
 	order: 2;

--- a/test/ignore-flexbox.css
+++ b/test/ignore-flexbox.css
@@ -1,0 +1,4 @@
+test {
+	display: flex;
+	gap: 20px;
+}

--- a/test/ignore-flexbox.expect.css
+++ b/test/ignore-flexbox.expect.css
@@ -1,0 +1,4 @@
+test {
+	display: flex;
+	gap: 20px;
+}

--- a/test/ignore-multicolumn.css
+++ b/test/ignore-multicolumn.css
@@ -1,0 +1,4 @@
+test {
+	columns: 3;
+	gap: 20px;
+}

--- a/test/ignore-multicolumn.expect.css
+++ b/test/ignore-multicolumn.expect.css
@@ -1,0 +1,4 @@
+test {
+	columns: 3;
+	gap: 20px;
+}


### PR DESCRIPTION
The gap property is supported by `flexbox` and `multi-column` layouts as well and should not be prefixed in these cituations. Is it enough to test whether the parent has a `display: grid` declaration ([./index.js:15](https://github.com/dweidner/postcss-gap-properties/blob/4dbc3a7e7bc274fb4b3586073994c5f702a139c8/index.js#L15))?

fixes #1 